### PR TITLE
On installing a new environment, one package on one node was

### DIFF
--- a/bootstrap_env/bootstrap.yml
+++ b/bootstrap_env/bootstrap.yml
@@ -12,6 +12,7 @@
     apt:
       pkg={{ item }}
       state=present
+      force=yes
     with_items:
       - vim
       - vlan

--- a/bootstrap_env/bootstrap.yml
+++ b/bootstrap_env/bootstrap.yml
@@ -12,7 +12,7 @@
     apt:
       pkg={{ item }}
       state=present
-      force=yes
+      update_cache=yes
     with_items:
       - vim
       - vlan


### PR DESCRIPTION
reporting a error trying to install, requesting confirmation.

Adding the force argument ensures a new deploy will not fail
on requiring input from user to install package that does not
exist on the system at time of deploy.